### PR TITLE
:recycle: Refactor: 의사가 수동으로 질문 생성하고 조회할때 AI 질문 생성이유 필드 NULL 처리

### DIFF
--- a/src/main/java/com/capd/capdbackend/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/capd/capdbackend/domain/survey/service/SurveyService.java
@@ -557,7 +557,6 @@ public class SurveyService {
                 .question(request.getQuestion())
                 .type(request.getType())
                 .options(request.getOptions())
-                .questionReason("의사가 직접 생성한 질문")
                 .status(QuestionStatus.APPROVED)
                 .build();
 


### PR DESCRIPTION
의사가 질문을 수동으로 생성하고 조회하게 되면 기존에는 AI 생성이유가 의사가 수동으로 질문 생성이라 화면에 표시됐지만 NULL 값으로 처리