### PR TITLE
🐛 [Fix] : 담당의사가 환자 등록후 환자 화면 오류 수정

### DIFF
--- a/src/main/java/com/capd/capdbackend/domain/patient/dto/response/PatientInfoResponse.java
+++ b/src/main/java/com/capd/capdbackend/domain/patient/dto/response/PatientInfoResponse.java
@@ -39,6 +39,9 @@ public class PatientInfoResponse {
     @Schema(description = "사용자 권한", example = "PATIENT")
     private Role role;
 
+    @Schema(description = "담당 의사 고유번호", example = "1")
+    private Long doctorId;
+
     @Schema(description = "회원가입 날짜", example = "2026-04-17T13:40:00")
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/capd/capdbackend/domain/patient/mapper/PatientInfoMapper.java
+++ b/src/main/java/com/capd/capdbackend/domain/patient/mapper/PatientInfoMapper.java
@@ -24,6 +24,7 @@ public class PatientInfoMapper {
                         ? Period.between(patient.getBirthDate(), LocalDate.now()).getYears()
                         : 0) // 기존에 있던 환자는 NULL로 인한 서버 오류 때문에 0으로 반환
                 .role(user.getRole())
+                .doctorId(patient.getDoctor() != null ? patient.getDoctor().getDoctorId() : null)
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())
                 .build();


### PR DESCRIPTION
담당 의사가 환자를 등록을 했지만 환자 화면에서는 계속해서 등록 전이라고 뜨는 버그 수정